### PR TITLE
Check for kernel's ability to call http kernel methods

### DIFF
--- a/src/GoogleCrawlDetectorServiceProvider.php
+++ b/src/GoogleCrawlDetectorServiceProvider.php
@@ -23,7 +23,10 @@ class GoogleCrawlDetectorServiceProvider extends ServiceProvider
      */
     public function boot(Kernel $kernel): void
     {
-        if (array_key_exists('web', $kernel->getMiddlewareGroups())) {
+        if (
+            $kernel instanceof \Illuminate\Foundation\Http\Kernel &&
+            array_key_exists('web', $kernel->getMiddlewareGroups())
+        ) {
             $kernel->appendMiddlewareToGroup('web', DetectGoogleCrawl::class);
         }
 


### PR DESCRIPTION
Hi maintainer,

This PR adds a check on the `$kernel` variable to make sure that it is an `\Illuminate\Foundation\Http\Kernel` kernel before moving further into calling methods (such as `getMiddlewareGroups` and `appendMiddlewareToGroup`) that don't belong in the `\Illuminate\Contracts\Http\Kernel` interface.

Also, this PR causes all checks to pass using the `composer check` script.

Regards,
David